### PR TITLE
Allow setting metadata of vertices & edges

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -133,7 +133,7 @@ type Edge[T comparable] struct {
 	source     *Vertex[T] // start point of the edges
 	dest       *Vertex[T] // destination or end point of the edges
 	properties EdgeProperties
-	metadata   any // optional metadata associated with the edge
+	Metadata   any // optional metadata associated with the edge
 }
 
 func NewEdge[T comparable](source *Vertex[T], dest *Vertex[T], options ...EdgeOptionFunc) *Edge[T] {
@@ -179,18 +179,13 @@ func (e *Edge[T]) Destination() *Vertex[T] {
 	return e.dest
 }
 
-// Metadata returns the metadata associated with the edge.
-func (e Edge[T]) Metadata() any {
-	return e.metadata
-}
-
 // Vertex represents a node or point in a graph
 type Vertex[T comparable] struct {
 	label      T            // uniquely identifies each vertex
 	neighbors  []*Vertex[T] // stores pointers to its neighbors
 	inDegree   int          // number of incoming edges to this vertex
 	properties VertexProperties
-	metadata   any // optional metadata associated with the vertex
+	Metadata   any // optional metadata associated with the vertex
 }
 
 func NewVertex[T comparable](label T, options ...VertexOptionFunc) *Vertex[T] {
@@ -255,9 +250,4 @@ func (v *Vertex[T]) Label() T {
 // Weight returns vertex label.
 func (v *Vertex[T]) Weight() float64 {
 	return v.properties.weight
-}
-
-// Metadata returns the metadata associated with the vertex.
-func (v *Vertex[T]) Metadata() any {
-	return v.metadata
 }


### PR DESCRIPTION
When storing data currently it needs to be all carried in the label. Allowing writing to the metadata would mean we can keep labels small and store actual data in the metadata field which is (as far as i can tell) unused.
I'm also open to moving to a field of a different name as "metadata" implies not the actual data.

I'd also be interested in lifting the type "any" to instead be a generic type of the vertex. Or perhaps converting vertex into an interface instead. Let me know if you think either of those are worthy changes.

This is my first contribution to this repo though so I'm happy to hear if I'm not seeing something :)!